### PR TITLE
Improve Alertmanager UI talk title

### DIFF
--- a/content/2017-munich/schedule.md
+++ b/content/2017-munich/schedule.md
@@ -316,8 +316,8 @@ title: Schedule
   <tr class="talk">
     <td>14:30</td>
     <td>
-      <a href="/2017-munich/talks/improving-user-and-developer-experience-of-alertmanager-ui">
-        Improving User and Developer Experience of Alertmanager UI
+      <a href="/2017-munich/talks/improving-user-and-developer-experience-of-the-alertmanager-ui">
+        Improving User and Developer Experience of the Alertmanager UI
       </a>
     </td>
     <td>

--- a/content/2017-munich/talks/improving-user-and-developer-experience-of-the-alertmanager-ui.md
+++ b/content/2017-munich/talks/improving-user-and-developer-experience-of-the-alertmanager-ui.md
@@ -2,7 +2,7 @@
 title: Improving User and Developer Experience of Alertmanager UI
 ---
 
-## Improving User and Developer Experience of Alertmanager UI
+## Improving User and Developer Experience of the Alertmanager UI
 
 Speaker: [Max Inden](/2017-munich/speakers/max-inden/)
 


### PR DESCRIPTION
As suggested by @juliusv in PR #23 prefixing "Alertmanager UI" with
"the" in the talk title.

Sorry for the late reply. Just changed the markdown file accordingly. Let me know if there is anything else to do.