### PR TITLE
Redirect to 2019 instead of 2018 on homepage

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,6 @@
 ---
 title: The Prometheus Conference
-redirect: /2018-munich/
+redirect: /2019-munich/
 ---
 
 ## PromCon - The Prometheus Conference


### PR DESCRIPTION
Signed-off-by: Julius Volz <julius.volz@gmail.com>