### PR TITLE
Update 2020 landing page to point to registration

### DIFF
--- a/content/2020-online/index.md
+++ b/content/2020-online/index.md
@@ -14,7 +14,7 @@ Get an impression of PromCon EU 2019:
 
 ## Registration
 
-Registration for PromCon Online 2020 will open soon.
+The registration is open. Register <a href="https://promcon.io/2020-online/register/">here</a>!
 
 ## Our sponsors
 


### PR DESCRIPTION
Seems like some users look here instead of the top-level navbar to find the registration page. 
https://www.reddit.com/r/PrometheusMonitoring/comments/hn3ryl/free_virtual_promcon_online_2020_next_week/fxc40h5/