### PR TITLE
Fix platinium sponsors logos

### DIFF
--- a/content/2021-losangeles/index.md
+++ b/content/2021-losangeles/index.md
@@ -65,8 +65,6 @@ Thanks to our sponsors!
 <h3>Platinum</h3>
 <div class="sponsor-logos">
   <a href="https://www.grafana.com/"><img alt="Grafana Labs sponsor logo" src="/assets/grafana-2021-la.svg" class="logo"/></a>
-</div>
-<div class="sponsor-logos">
   <a href="https://www.timescale.com/"><img alt="Timescale sponsor logo" src="/assets/timescale-2021.svg" class="logo"/></a>
 </div>
 


### PR DESCRIPTION
Logos should be side-to-side, like e.g. diamond. This is also what was
done previous years.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>