### PR TITLE
Modify title for the native histogram talk

### DIFF
--- a/content/2022-munich/schedule.md
+++ b/content/2022-munich/schedule.md
@@ -40,7 +40,7 @@ title: Schedule
    <tr class="talk">
     <td>9:45</td>
     <td>
-      <a href="../talks/native-histograms-in-prometheus-">Native Histograms in Prometheus v2.40.0</a>
+      <a href="../talks/native-histograms-in-prometheus">Native Histograms in Prometheus</a>
     </td>
     <td>
       <a href="../speakers/ganesh-vernekar">Ganesh Vernekar</a>

--- a/content/2022-munich/talks/native-histograms-in-prometheus.md
+++ b/content/2022-munich/talks/native-histograms-in-prometheus.md
@@ -1,8 +1,8 @@
 ---
-title: "Native Histograms in Prometheus v2.40.0"
+title: "Native Histograms in Prometheus"
 ---
 
-## Native Histograms in Prometheus v2.40.0
+## Native Histograms in Prometheus
 
 Speaker(s): [Ganesh Vernekar](../../speakers/ganesh-vernekar)
 


### PR DESCRIPTION
I believe this talk will be referred back to know about this feature in Prometheus. Also the talk content is such that is it not specific to v2.40.0; it is a talk describing the feature and how to use in general. So I would like to request a change in the title which makes it more generic.

I also changed the talk URL, please let me know if it will break anything.

cc @RichiH @juliusv 