### PR TITLE
fix: speakers links and bio

### DIFF
--- a/content/2023-berlin/speakers/david-calvert.md
+++ b/content/2023-berlin/speakers/david-calvert.md
@@ -4,4 +4,6 @@ title: "David Calvert"
 
 ## [David Calvert](https://twitter.com/0xDC_)
 
-David is a Site Reliability Engineer at Oqton, working remotely from the south of France. He’s currently focused on observability, reliability, and security aspects of cloud infrastructure. Outside of work, he enjoys rock climbing, and playing old graphic adventures games.
+Working at Oqton
+
+David is a Site Reliability Engineer working remotely from the south of France. He’s currently focused on observability, reliability, and security aspects of cloud infrastructure. Outside of work, he enjoys rock climbing, and playing old graphic adventure games.

--- a/content/2023-berlin/speakers/david-calvert.md
+++ b/content/2023-berlin/speakers/david-calvert.md
@@ -2,8 +2,6 @@
 title: "David Calvert"
 ---
 
-## David Calvert
-
-Working at Oqton
+## [David Calvert](https://twitter.com/0xDC_)
 
 David is a Site Reliability Engineer at Oqton, working remotely from the south of France. He’s currently focused on observability, reliability, and security aspects of cloud infrastructure. Outside of work, he enjoys rock climbing, and playing old graphic adventures games.

--- a/content/2023-berlin/talks/yet-another-streaming-promql-engine.md
+++ b/content/2023-berlin/talks/yet-another-streaming-promql-engine.md
@@ -4,7 +4,7 @@ title: "Yet Another Streaming PromQL Engine"
 
 ## Yet Another Streaming PromQL Engine
 
-Speaker(s): [Charles Korn](../../speakers/charles-korn)
+Speaker(s): [György Krajcsovits](../../speakers/gyorgy-krajcsovits)
 
 Mimir is great at ingesting enormous amounts of time series data. But we think it can be even better at querying enormous amounts of time series data. So we’ve been working to improve Mimir’s query performance and resource consumption, with the goal to evaluate queries faster while also reducing CPU utilisation and peak memory consumption.
 


### PR DESCRIPTION
Noticed the speaker link was broken for "Yet Another Streaming PromQL Engine" (recently replaced in https://github.com/promcon/website/pull/290).
Also took this opportunity to add my twitter and remove a duplicate entry in my bio. 