### PR TITLE
Add CNCF as diamond sponsor

### DIFF
--- a/content/2023-berlin/index.md
+++ b/content/2023-berlin/index.md
@@ -40,6 +40,7 @@ The event Hashtag is [#PromCon](https://twitter.com/search?q=%23PromCon).
 
 <h3>Diamond</h3>
 <div class="sponsor-logos">
+  <a href="https://cncf.io/"><img src="/assets/cncf_logo.svg" class="logo"/></a>
   <a href="https://grafana.com/"><img src="/assets/grafana_labs_logo_light.svg" class="logo"/></a>
 </div>
 


### PR DESCRIPTION
Somehow we overlooked this and weren't sure if this should be the default.
