### PR TITLE
Update the talk title in the schedule

### DIFF
--- a/content/2023-berlin/schedule.md
+++ b/content/2023-berlin/schedule.md
@@ -50,7 +50,7 @@ title: Schedule
    <tr class="talk">
     <td>9:45</td>
     <td>
-      <a href="../talks/perses">Perses</a>
+      <a href="../talks/perses">Perses: The CNCF candidate for observability visualisation</a>
     </td>
     <td>
       <a href="../speakers/augustin-husson">Augustin Husson</a>


### PR DESCRIPTION
Seems like we missed updating the talk title in the schedule overview in #293. 