### PR TITLE
Add PromCon 2024

### DIFF
--- a/content/2024-berlin/diversity.md
+++ b/content/2024-berlin/diversity.md
@@ -1,0 +1,25 @@
+---
+title: Diversity Scholarships
+---
+
+## Scholarships + Travel Funding
+
+The Dan Kohn Scholarship + Travel Fund is intended to enable open source developers and community members to attend events that they would otherwise be unable to attend due to a lack of funding. We place an emphasis on funding applicants who are from historically underrepresented or untapped groups and/or those of lower socioeconomic status. If you work for a company that has the ability to fund your travel, we ask that you not apply, to save funds for those that need it.
+
+Fill out the form using the button below to have your funding request considered. In order to maximize spending, travel fund assistance may only be used for: Coach airfare tickets, accommodation for the dates of the event plus one night prior to the event start date, ground transportation to/from the airport. Funds may not be used for miscellaneous travel expenses including food, visa costs, non-airport transportation, baggage fees, etc.
+
+A standard in-person ticket for the PromCon EU 2024 will be included.
+
+Receipt of Travel Funding does not guarantee entry to the event.  Recipients need to adhere to The Linux Foundation COVID-19 rules and regulations. If the recipient does not meet COVID-19 requirements for the event, the travel fund allotted is null and void. Should the recipient not be able to travel due to COVID-19 and travel has already been booked, the recipient will need to work with airlines and hotels to receive a refund. If a refund is not a possibility, The Linux Foundation will reimburse for incurred travel expenses within the allotted amount.
+
+For questions, please contact <a href="mailto:travelfund@linuxfoundation.org">travelfund@linuxfoundation.org</a>.
+
+
+<a class="btn btn-lg btn-default" href="https://events.linuxfoundation.org/about/travel-fund-request/" target="_blank" role="button">
+  <i class="fa fa-pen"></i>&nbsp;&nbsp;Apply for scholarships + Travel funding
+</a>
+
+### Timeline
+
+* Scholarship applications due: Friday, August 2, 2024
+* All applicants will be notified by: Friday, August 16, 2024

--- a/content/2024-berlin/giggity.json
+++ b/content/2024-berlin/giggity.json
@@ -1,0 +1,24 @@
+{
+    "version": 20220811,
+    "url": "https://promcon.io/2024-berlin/schedule.xml",
+    "title": "PromCon EU 2024",
+        "start": "2022-09-11",
+        "end": "2022-09-12",
+        "metadata": {
+            "icon": "https://promcon.io/assets/favicons/apple-touch-icon.png",
+            "links": [
+                {
+                    "url": "https://promcon.io/2024-berlin/",
+                    "title": "Website"
+                },
+                {
+                    "url": "",
+                    "title": "Venue location"
+                },
+                {
+                    "url": "https://promcon.io/coc/",
+                    "title": "Code of Conduct"
+                }
+            ]
+        }
+}

--- a/content/2024-berlin/index.md
+++ b/content/2024-berlin/index.md
@@ -1,0 +1,41 @@
+---
+title: Overview
+---
+
+## Overview
+
+PromCon EU 2024 is the ninth conference fully dedicated to the
+[Prometheus monitoring system](https://prometheus.io/). It will take place
+2024-09-11 & 2024-09-12 (Wed & Thu) in Berlin as a single-track event with space for 300 attendees.
+
+PromCon aims to connect Prometheus users and developers from around the world in order to exchange knowledge, best practices, and experience gained around using Prometheus. We also want to collaborate to build a community and grow professional connections around systems and service monitoring.
+
+Get an impression of PromCon EU 2019:
+
+<%= youtube_player("TUbj9ykgafM") %>
+
+## Venue Information
+
+To be announced (TBA) once the contract has been signed. 
+
+## Code of Conduct
+ 
+To make PromCon a welcoming and harrassment-free experience for everyone, we
+follow the [Linux Foundation's Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/),
+which applies to all attendees including speakers, guests, and
+organizers.
+ 
+## Hashtag
+ 
+The event Hashtag is [#PromCon](https://twitter.com/search?q=%23PromCon).
+
+## Our sponsors
+
+Sponshorship will open soon.
+
+## Contact
+
+PromCon is organized by the [Prometheus developer
+community](https://prometheus.io/community/). For PromCon-related inquiries,
+please contact the [PromCon team](mailto:promcon-organizers@googlegroups.com).
+This year's edition is led by [Polar Signals](https://polarsignals.com/).

--- a/content/2024-berlin/register.md
+++ b/content/2024-berlin/register.md
@@ -1,0 +1,11 @@
+---
+title: Register
+---
+
+## Register to attend
+
+Registration will open soon!
+
+## Letter for Visa
+
+If you need a letter to apply for a Visa, use [this link](https://events.linuxfoundation.org/about/visa-request/) to raise a request for the same. Be sure to select <b>PromCon EU</b> while selecting the event.

--- a/content/2024-berlin/sponsor.md
+++ b/content/2024-berlin/sponsor.md
@@ -1,0 +1,75 @@
+---
+title: Become a Sponsor
+---
+
+## Become a sponsor
+
+As a community conference with a low entrance fee, we depend on sponsors for
+making PromCon possible.
+
+Do you want to help make this happen and **get your company featured in videos,
+banners, and printed materials?**
+
+## I want to sponsor PromCon. What do I do?
+
+Sponsorships will open soon!
+
+If you wish to take advantage of swag distribution, booth space, or free
+attendee tickets, please let us know in advance.
+
+## Why sponsor PromCon?
+
+Prometheus is a leading open-source monitoring system and time series database
+which is used by companies of all sizes for their mission-critical monitoring.
+
+PromCon attracts a crowd of experienced and influential
+infrastructure engineers, both via in-person attendance and through video
+recordings that are made available to the public after the conference.
+**Featuring your name and brand in front of this audience will drive the
+adoption of your products and services in the infrastructure world, as well as
+present you with potential hiring opportunities!** And of course, if your
+organisation is using Prometheus already, you will benefit directly from helping
+its community to grow and thrive.
+
+## How will the money be used?
+
+We will use the sponsorship money to pay for conference expenses such as:
+
+* Professional video recordings of all talks
+* Catering for all attendees
+* Printed materials, banners, lanyards, etc.
+* Evening after-party (unless sponsored separately)
+* Speaker reimbursements, if funding allows for it
+* Diversity scholarships
+
+PromCon is a community-organized conference with no financial profit motive. Any
+leftover funds will be used for future conferences or the project.
+
+## Terms and conditions
+
+* Sponsorship application is handled on a "first-come, first-served" basis.
+* Sponsors should be committed to the use of the Prometheus monitoring system
+  and supportive of PromCon's mission to provide a conference aimed at the
+  Prometheus community: Prometheus users and developers of all skill levels.
+* The organisation of PromCon being carried out by the Prometheus
+  development community (contact: [PromCon Organizers](mailto:promcon-organizers@googlegroups.com)).
+  All financial matters are handled on behalf of the PromCon team by the
+  [Linux Foundation](https://www.linuxfoundation.org/).
+* The PromCon organizers retain the right to reject any sponsor that they
+  deem to be inappropriate.
+* After written acceptance by the PromCon organizers, the sponsor should
+  provide the sponsorship funds, logo image in an appropriate format, and other
+  details required within 30 days of receipt of the acceptance, and in any
+  case one week before the start of the conference.
+* Sponsorship pledges cannot be processed without payment.
+* Sponsors may not sublet, assign or apportion any part of the item(s)
+  sponsored nor represent, advertise, or distribute literature or materials for
+  the products or services of any other firm or organisation.
+* Linux Foundation and/or individual PromCon organizers will not be
+  liable for damage or loss to sponsors' properties by fire, theft, accident or
+  any other cause whether the result of negligence or otherwise or case of
+  force majeure.
+* Further sponsorship terms will be laid out in a sponsorship agreement
+  between Linux Foundation and the sponsor.
+
+Thanks for your interest in sponsoring PromCon!

--- a/content/2024-berlin/submit.md
+++ b/content/2024-berlin/submit.md
@@ -1,0 +1,26 @@
+---
+title: Submit Talk
+---
+
+## Submit a talk
+
+The PromCon Call for Papers (CfP) will open soon!
+
+We are accepting talk proposals around the following topics, with experience
+levels ranging from beginner to expert:
+
+* Integrating with Prometheus
+* Using Prometheus
+* Prometheus use case reports
+* Prometheus fundamentals and philosophy
+* Prometheus internals and core development
+
+**Speaker reimbursements:** Since PromCon is a non-commercial community
+conference, speaker reimbursements for travel and accommodation will depend on
+available funding. If you want to give a talk but cannot get reimbursed by your
+company, please submit a proposal anyway and let us know in the "Additional note
+to the selection committee" field. We will then let you know what we can offer.
+
+**Diversity:** For diversity speakers, we will try extra hard to find a way to
+help with travel and/or accommodation. No promises made, but we will honestly
+try to make it work.

--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,6 @@
 ---
 title: The Prometheus Conference
-redirect: /2023-berlin/
+redirect: /2024-berlin/
 ---
 
 ## PromCon - The Prometheus Conference

--- a/layouts/container.html
+++ b/layouts/container.html
@@ -22,7 +22,7 @@
           <% conferences.each do |conference| %>
           <a href="<%= conference.path %>"><%= conference.title %></a> |
           <% end %>
-          &copy; Prometheus Authors 2016-2023
+          &copy; Prometheus Authors 2016-2024
         </p>
         <p class="pull-right">
           <%= conference.banner_copyright %>

--- a/lib/helpers/conferences.rb
+++ b/lib/helpers/conferences.rb
@@ -152,6 +152,22 @@ def conferences
       },
       Banner.new('berlin-banner', 'Céline Lang', 'https://www.flickr.com/photos/line68/10555465713'),
     ),
+    Conference.new(
+      'PromCon EU 2024',
+      'The Prometheus conference — September 11 - 12 in Berlin',
+      '/2024-berlin/',
+      {
+        '/2024-berlin/' => 'Overview',
+        # '/2024-berlin/register/' => 'Register',
+        '/2024-berlin/diversity/' => 'Diversity',
+        # '/2024-berlin/submit/' => 'CfP',
+        #'/2024-berlin/schedule/' => 'Schedule',
+        # '/2024-berlin/sponsor/' => 'Sponsor',
+        # '/2024-berlin/stream/' => 'Live Stream',
+        '/coc/' => 'Code of Conduct',
+      },
+      Banner.new('berlin-banner', 'Céline Lang', 'https://www.flickr.com/photos/line68/10555465713'),
+    ),
   ]
 end
 


### PR DESCRIPTION
Today, Monday June 3rd at 16:00 CEST, we want to announce PromCon 2024 happening in Berlin. 
This updates the website. 