### PR TITLE
Update 2024 Remote-Write talk description

### DIFF
--- a/content/2024-berlin/talks/unlocking-cost-savings--new-possibilities-your-guide-to-prometheus-remote-write-20.md
+++ b/content/2024-berlin/talks/unlocking-cost-savings--new-possibilities-your-guide-to-prometheus-remote-write-20.md
@@ -10,19 +10,5 @@ Prometheus Remote Write is the protocol used to send Prometheus metrics from Pro
 
 Welcome to Remote Write 2.0! In this talk, Bartek and Alex, Prometheus maintainers and RW2.0 spec. co-authors, will introduce you to the next iteration of the popular protocol which adds more functionality while cutting your egress costs up to 60%, and keeps the previous versions easy-to-implement stateless design!
 
-The audience will learn what's changed in the second version of Remote Write, what it unlocks, and how easy it is to update or adopt. Finally, the speakers will share the latest benchmarks and differences with the common alternatives.
-
-There are many existing implementations of Remote Write Senders and Receivers; including CNCF projects like Prometheus itself, Cortex, Thanos, and OpenTelemetry Collector. A list is maintained on the Prometheus docs website.
-
-Remote Write 2.0 is a step forward in the efficiency and supported use-cases of the protocol/spec, aggregating the newest features Prometheus ecosystem delivered since the Remote-Write 1.0.
-
-Since Prometheus and common vendors will soon support Remote Write 2.0, as the protocol co-authors, we thought it would be a great idea to:
-
-* Share what’s changed and why it’s important in the ecosystem to use and adopt.
-* For o11y users to share what Remote Write 2.0 enables for them, especially if they use Prometheus as a sender.
-* For o11y Dev+OSS+Vendor ecosystem share why and how to adopt it for both sending and receiving.
-* Share how it compares with alternatives like OpenTelemetry OTLP (TL;DR: a bit of apples and oranges and there are use cases and trade-offs for both).
-* What makes it so good with egress (and also compute) cost.
-
-Hope, audience will enjoy this talk! (: 
+The audience will learn what's changed in the second version of Remote Write, what it unlocks, and how easy it is to update or adopt. Finally, the speakers will share the latest benchmarks and relation to the alternatives like OpenTelemetry's OTLP.
 


### PR DESCRIPTION
The second part removed was a "Additional Notes" that are NOT meant to share as a talk description - it supposed to be notes to the reviewers. cc @alexgreenbank we put this in wrong place in sessionize.

Nothing secret there, just duplicated and unnecessary details and spoiler alerts.