### PR TITLE
2024: Hide Scholarship and Sponsor pages

### DIFF
--- a/lib/helpers/conferences.rb
+++ b/lib/helpers/conferences.rb
@@ -159,10 +159,10 @@ def conferences
       {
         '/2024-berlin/' => 'Overview',
         '/2024-berlin/register/' => 'Register',
-        '/2024-berlin/scholarship/' => 'Scholarship',
+#       '/2024-berlin/scholarship/' => 'Scholarship',
 #         '/2024-berlin/submit/' => 'CfP',
         '/2024-berlin/schedule/' => 'Schedule',
-        '/2024-berlin/sponsor/' => 'Sponsor',
+#       '/2024-berlin/sponsor/' => 'Sponsor',
         # '/2024-berlin/stream/' => 'Live Stream',
         '/2024-berlin/health-and-safety/' => 'Health & Safety',
         '/coc/' => 'Code of Conduct',


### PR DESCRIPTION
They aren't of much help anymore and without them the navigation is much cleaner.
