### PR TITLE
Update PromCon EU 2026 CFP deadline to 2026-07-19 and note extension

### DIFF
--- a/content/2026-munich/index.md
+++ b/content/2026-munich/index.md
@@ -32,7 +32,7 @@ organizers.
 
 ## CFP
 
-The [PromCon Call for Papers](https://sessionize.com/promcon-eu-2026/) is open until 2025-07-13 11:59 PM CEST(UTC+2)
+The [PromCon Call for Papers](https://sessionize.com/promcon-eu-2026/) has been extended and is now open until 2026-07-19 11:59 PM CEST(UTC+2)
 
 ## Registration
 

--- a/content/2026-munich/submit.md
+++ b/content/2026-munich/submit.md
@@ -1,8 +1,16 @@
+---
+title: Submit Talk
+---
+
 ## Submit a talk
 
-The _PromCon Call for Papers_ will open soon.
+The [PromCon Call for Papers](https://sessionize.com/promcon-eu-2026/) has been extended and is now open until 2026-07-19 11:59 PM CEST(UTC+2).
 
-We will be accepting talk proposals around the following topics, with experience levels ranging from beginner to expert:
+<a class="btn btn-lg btn-default" href="https://sessionize.com/promcon-eu-2026/" target="_blank" role="button">
+  <i class="fa fa-briefcase"></i>&nbsp;&nbsp;Submit to speak
+</a>
+
+We are accepting talk proposals around the following topics, with experience levels ranging from beginner to expert:
 
 * Prometheus internals and core development
 * Prometheus fundamentals and philosophy

--- a/lib/helpers/conferences.rb
+++ b/lib/helpers/conferences.rb
@@ -194,6 +194,7 @@ def conferences
         '/2026-munich/' => 'Overview',
         '/2026-munich/register/' => 'Register',
         '/2026-munich/diversity/' => 'Diversity',
+        '/2026-munich/submit/' => 'CFP',
         '/2026-munich/sponsor/' => 'Sponsor',
         '/2026-munich/health-and-safety/' => 'Health & Safety',
         '/coc/' => 'Code of Conduct',


### PR DESCRIPTION
This PR updates the Call for Papers (CFP) deadline for PromCon EU 2026 from 2025-07-13 to 2026-07-19 across `index.md` and `submit.md`, notes that the deadline has been extended, and adds standard frontmatter plus the Sessionize link to `submit.md`.